### PR TITLE
Allowing Aeson 1.0 and bumping version

### DIFF
--- a/ua-parser.cabal
+++ b/ua-parser.cabal
@@ -1,6 +1,6 @@
 name:                ua-parser
 description:         Please refer to the git/github README on the project for example usage.
-version:             0.7.1
+version:             0.7.2
 synopsis:            A library for parsing User-Agent strings, official Haskell port of ua-parser
 license:             BSD3
 license-file:        LICENSE
@@ -40,7 +40,7 @@ library
     , text
     , pcre-light
     , yaml             >= 0.7 && < 0.9
-    , aeson            >= 0.7 && < 0.12
+    , aeson            >= 0.7 && < 1.1
     , data-default
     , file-embed       < 0.1
 


### PR DESCRIPTION
Hey!

I am using the latest version of Aeson and wanted to use `ua-parser` as well. Unfortunately there's a  clash in the dependencies, I have however tried to compile `ua-parser` with the latest Aeson and it seems to be no code changes necessary.

Hence, with this PR i'm basically just requesting to bump the version bound, thanks :)